### PR TITLE
fix(security): parse signal addresses in linear time

### DIFF
--- a/src/__test__/signal-protocol-address.test.ts
+++ b/src/__test__/signal-protocol-address.test.ts
@@ -29,7 +29,7 @@ describe('SignalProtocolAddress', function () {
     })
     describe('fromString', function () {
         test('throws on a bad inputs', () => {
-            const bads = ['', null, {}]
+            const bads = ['', null, {}, 'name', '.1', 'name.', 'name.one', 'name.1extra']
             for (const bad of bads) {
                 expect(() => {
                     // We are testing data that Typescript wouldn't allow
@@ -45,6 +45,12 @@ describe('SignalProtocolAddress', function () {
             expect(address.deviceId).toBe(deviceId)
             expect(address.getName()).toBe(name)
             expect(address.name).toBe(name)
+        })
+
+        test('preserves dots in the address name', () => {
+            const address = SignalProtocolAddress.fromString('tenant.alice.7')
+            expect(address.name).toBe('tenant.alice')
+            expect(address.deviceId).toBe(7)
         })
     })
 })

--- a/src/signal-protocol-address.ts
+++ b/src/signal-protocol-address.ts
@@ -20,11 +20,23 @@ export class SignalProtocolAddress implements SignalProtocolAddressType {
      * @throws Error if the string is invalid
      */
     static fromString(s: string): SignalProtocolAddress {
-        if (!s.match(/.*\.\d+/)) {
+        if (typeof s !== 'string') {
             throw new Error(`Invalid SignalProtocolAddress string: ${s}`)
         }
-        const parts = s.split('.')
-        return new SignalProtocolAddress(parts[0], parseInt(parts[1]))
+
+        const separator = s.lastIndexOf('.')
+        const name = s.slice(0, separator)
+        const deviceText = s.slice(separator + 1)
+        const hasOnlyDigits =
+            deviceText.length > 0 &&
+            Array.from(deviceText).every((char) => char >= '0' && char <= '9')
+        const deviceId = Number(deviceText)
+
+        if (separator <= 0 || !hasOnlyDigits || !Number.isSafeInteger(deviceId)) {
+            throw new Error(`Invalid SignalProtocolAddress string: ${s}`)
+        }
+
+        return new SignalProtocolAddress(name, deviceId)
     }
 
     private _name: string


### PR DESCRIPTION
## Summary
- replace the potentially polynomial regex with a linear last-separator parser
- validate device IDs without a regex
- preserve dotted address names and reject malformed suffixes

## Validation
- build passed
- targeted Jest suite: 6/6 passed
- lint: 0 errors (2 existing generated-file warnings)
- `git diff --check` passed